### PR TITLE
Fixed deprecated functions warnings.

### DIFF
--- a/train.py
+++ b/train.py
@@ -126,13 +126,13 @@ with tf.Graph().as_default():
         checkpoint_prefix = os.path.join(checkpoint_dir, "model")
         if not os.path.exists(checkpoint_dir):
             os.makedirs(checkpoint_dir)
-        saver = tf.train.Saver(tf.all_variables())
+        saver = tf.train.Saver(tf.global_variables())
 
         # Write vocabulary
         vocab_processor.save(os.path.join(out_dir, "vocab"))
 
         # Initialize all variables
-        sess.run(tf.initialize_all_variables())
+        sess.run(tf.global_variables_initializer())
 
         def train_step(x_batch, y_batch):
             """


### PR DESCRIPTION
There are some warnings for deprecated functions that we should stop using:
```
WARNING:tensorflow:From ./train.py:129 in <module>.: all_variables (from tensorflow.python.ops.variables) is deprecated and will be removed after 2016-03-02.
Instructions for updating:
Please use tf.global_variables instead.
WARNING:tensorflow:From ./train.py:135 in <module>.: initialize_all_variables (from tensorflow.python.ops.variables) is deprecated and will be removed after 2017-03-02.
Instructions for updating:
Use `tf.global_variables_initializer` instead.
```