### PR TITLE
Fixes the required TF version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ It is slightly simplified implementation of Kim's [Convolutional Neural Networks
 ## Requirements
 
 - Python 3
-- Tensorflow > 0.8
+- Tensorflow > 0.12
 - Numpy
 
 ## Training


### PR DESCRIPTION
TF 0.10-0.11 do not have the `tf.global_variables()` attribute and will fail, couldn't find the API for 0.8/0.9 so I'd assume they are old enough not to be mentioned.