### PR TITLE
Minor fix to comment typo

### DIFF
--- a/text_cnn.py
+++ b/text_cnn.py
@@ -73,7 +73,7 @@ class TextCNN(object):
             self.scores = tf.nn.xw_plus_b(self.h_drop, W, b, name="scores")
             self.predictions = tf.argmax(self.scores, 1, name="predictions")
 
-        # CalculateMean cross-entropy loss
+        # Calculate mean cross-entropy loss
         with tf.name_scope("loss"):
             losses = tf.nn.softmax_cross_entropy_with_logits(logits=self.scores, labels=self.input_y)
             self.loss = tf.reduce_mean(losses) + l2_reg_lambda * l2_loss


### PR DESCRIPTION
Added a space between 'Calculate' and 'mean'.